### PR TITLE
Use Authenticate public endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,8 +821,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1114,6 +1116,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1145,7 @@ name = "kittengrid-agent"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "async-trait",
  "axum",
  "axum-extra",
  "base64 0.22.1",
@@ -1138,6 +1156,7 @@ dependencies = [
  "futures",
  "futures-util",
  "headers",
+ "jsonwebtoken",
  "log",
  "once_cell",
  "rand 0.8.5",
@@ -1411,10 +1430,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1550,6 +1597,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1788,9 +1845,24 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "getrandom 0.2.15",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2009,6 +2081,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,6 +2128,12 @@ name = "spin"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13287b4da9d1207a4f4929ac390916d64eacfe236a487e9a9f5b3be392be5162"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -2519,6 +2609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,7 +3003,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "ring",
+ "ring 0.16.20",
  "spin 0.7.1",
  "subtle",
  "x25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ rtnetlink = "0.14.1"
 futures = "0.3.31"
 wireguard-rs   = { git = "https://github.com/kittengrid/wireguard-rs.git" }
 x25519-dalek = "1.2.0"
+jsonwebtoken = "9.3.0"
+async-trait = "0.1.83"
 
 [dependencies.uuid]
 version = "1.11.0"

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -1,2 +1,2 @@
-pub mod services;
+pub mod public;
 pub mod sys;

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -1,0 +1,1 @@
+pub mod services;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,11 +26,23 @@ pub fn router(services: Arc<crate::service::Services>) -> Router {
     Router::new()
         .route("/sys/hello", get(endpoints::sys::hello))
         .route("/sys/shutdown", post(endpoints::sys::shutdown))
-        .route("/services", get(endpoints::services::index))
-        .route("/services/:id/stdout", get(endpoints::services::stdout))
-        .route("/services/:id/stderr", get(endpoints::services::stderr))
-        .route("/services/:id/stop", post(endpoints::services::stop))
-        .route("/services/:id/start", post(endpoints::services::start))
+        .route("/public/services", get(endpoints::public::services::index))
+        .route(
+            "/public/services/:id/stdout",
+            get(endpoints::public::services::stdout),
+        )
+        .route(
+            "/public/services/:id/stderr",
+            get(endpoints::public::services::stderr),
+        )
+        .route(
+            "/public/services/:id/stop",
+            post(endpoints::public::services::stop),
+        )
+        .route(
+            "/public/services/:id/start",
+            post(endpoints::public::services::start),
+        )
         .with_state(services)
         .layer(
             TraceLayer::new_for_http()

--- a/src/log_generator/main.rs
+++ b/src/log_generator/main.rs
@@ -30,10 +30,12 @@ fn main() {
 
     for _ in 0..args.burst {
         println!("{}", generate_line(args.name));
+        eprintln!("{}", generate_line(args.name));
     }
 
     loop {
         println!("{}", generate_line(args.name));
+        eprintln!("{}", generate_line(args.name));
         std::thread::sleep(std::time::Duration::from_millis(args.sleep as u64));
     }
 }


### PR DESCRIPTION
This:
- Moves `/services` into `/public/services` with the idea that everything bellow `/public` will me publicy accessible.
- Adds JWT authentication in `/public/services`. Using the api_key as the secret, the idea is that Rails will be able to generate tokens to be used by the agent.