### PR TITLE
Enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,7 @@ dependencies = [
  "futures-util",
  "headers",
  "jsonwebtoken",
+ "libc",
  "log",
  "once_cell",
  "openssl",
@@ -1057,9 +1058,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,7 @@ features = [
     "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
     "serde",
 ]
+
+[dev-dependencies]
+libc = "0.2.174"
+tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,9 @@ pub struct Config {
     #[arg(short, long, env("KITTENGRID_LOG_LEVEL"))]
     pub log_level: String,
 
+    #[arg(long, env("KITTENGRID_SHOW_SERVICES_OUTPUT"))]
+    pub show_services_output: bool,
+
     #[arg(short, long, env("KITTENGRID_WORK_DIR"))]
     pub work_directory: String,
 

--- a/src/kittengrid_agent.rs
+++ b/src/kittengrid_agent.rs
@@ -136,13 +136,19 @@ impl KittengridAgent {
     }
 
     /// Starts services in the agent.
-    pub async fn spawn_services(&self) -> Result<(), KittengridAgentError> {
+    pub async fn spawn_services(
+        &self,
+        show_services_output: bool,
+    ) -> Result<(), KittengridAgentError> {
         for (id, service) in self.services.descriptions().await {
             let name = service.name();
             info!("Spawning service: {} ({}).", id, name);
             let service = self.services.fetch(id).await;
             let service = service.unwrap();
             let mut service = service.lock().await;
+            if show_services_output {
+                service.show_output();
+            }
 
             if let Err(e) = service.start(Arc::new(self.api.clone())).await {
                 error!("Failed to spawn service: {}.", name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn main() {
         }
 
         info!("All interfaces up. Spawning services.");
-        match agent.spawn_services().await {
+        match agent.spawn_services(config.show_services_output).await {
             Ok(_) => {
                 info!("Successfully spawned services.");
             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -608,4 +608,33 @@ mod test {
             .await;
         service.stop().await.unwrap();
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    async fn test_spawn_inherits_env_vars() {
+        initialize_tests();
+        let config = crate::config::ServiceConfig {
+            name: "/usr/bin/env".to_string(),
+            ..Default::default()
+        };
+        let mut service = Service::from(config);
+
+        std::env::set_var("TEST_ENV", "test_value");
+
+        let result = service.start(Arc::new(None)).await;
+        assert!(result.is_ok());
+
+        let mut receiver = service.subscribe_to_stream(ServiceStream::Stdout).await;
+
+        // consume until we get TEST_ENV=test_value
+        let mut found = false;
+        while let Some(data) = receiver.recv().await {
+            if data == *"TEST_ENV=test_value\n" {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "TEST_ENV=test_value not found in output");
+
+        service.stop().await.unwrap();
+    }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -124,6 +124,13 @@ impl Service {
         }
     }
 
+    pub fn show_output(&mut self) {
+        self.stdout
+            .set_output_mode(crate::persisted_buf_reader_broadcaster::OutputMode::Stdout);
+        self.stderr
+            .set_output_mode(crate::persisted_buf_reader_broadcaster::OutputMode::Stderr);
+    }
+
     pub async fn unsubscribe_from_stream(
         &mut self,
         receiver: BufferReceiver,


### PR DESCRIPTION
Allows using an ENV var to control whether we want the service stderr/stdout to be sent to the terminal that executes the agent.

we can set  `KITTENGRID_SHOW_SERVICES_OUTPUT` to true/false