### PR TITLE
Add --start-terminal flag to control the terminal

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -119,11 +119,16 @@ pub struct Config {
     #[arg(long, env("KITTENGRID_WORKFLOW_RUN_ID"))]
     pub workflow_run_id: String,
 
+    /// Starts services defined in the configuration file [default: false]
     #[arg(long, env("KITTENGRID_START_SERVICES"))]
     pub start_services: bool,
 
     #[arg(long, env("KITTENGRID_LAST_COMMIT_SHA"))]
     pub last_commit_sha: String,
+
+    /// Whether to start a terminal service using ttyd [default: false]
+    #[arg(long, env("KITTENGRID_START_TERMINAL"))]
+    pub start_terminal: bool,
 
     #[clap(skip)]
     pub services: Vec<ServiceConfig>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,40 @@ async fn main() {
         }
     }
 
+    if config.start_terminal {
+        info!("Starting debugging terminal.");
+        let id = uuid::Uuid::new_v4();
+        match lib::ttyd::Executable::default()
+            .start(&format!("/{}", id))
+            .await
+        {
+            Ok(port) => {
+                match agent
+                    .register_service(
+                        id,
+                        "ttyd",
+                        port,
+                        Some(format!("/{}/token", id).to_string()),
+                        Some(format!("/{}", id).to_string()),
+                        true,
+                    )
+                    .await
+                {
+                    Ok(public_url) => {
+                        info!("Terminal available at: {}", public_url);
+                    }
+                    Err(e) => {
+                        error!("Failed to register service: {}. {}.", "ttyd", e)
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to start TTYD: {}.", e);
+                exit(1);
+            }
+        }
+    }
+
     if config.start_services {
         info!("Service start disabled. Exiting.");
         agent
@@ -79,40 +113,10 @@ async fn main() {
                 exit(1);
             }
         }
-
-        info!("Starting debugging terminal.");
-        let id = uuid::Uuid::new_v4();
-        match lib::ttyd::Executable::default()
-            .start(&format!("/{}", id))
-            .await
-        {
-            Ok(port) => {
-                match agent
-                    .register_service(
-                        id,
-                        "ttyd",
-                        port,
-                        Some(format!("/{}/token", id).to_string()),
-                        Some(format!("/{}", id).to_string()),
-                        true,
-                    )
-                    .await
-                {
-                    Ok(public_url) => {
-                        info!("Terminal available at: {}", public_url);
-                    }
-                    Err(e) => {
-                        error!("Failed to register service: {}. {}.", "ttyd", e)
-                    }
-                }
-            }
-            Err(e) => {
-                error!("Failed to start TTYD: {}.", e);
-                exit(1);
-            }
-        }
-
         info!("All services spawned. Waiting for incomming requests.");
+    }
+
+    if config.start_services || config.start_terminal {
         agent.wait(listener).await;
     } else {
         info!("Service start disabled. Exiting.");


### PR DESCRIPTION
Add --start-terminal flag to control whether or not we want the terminal to be ran